### PR TITLE
Fix Google Assistant serialization error and improve error logging

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -37,8 +37,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             async with async_timeout.timeout(20):
                 return await client.get_all_data()
         except RequestTimeout as err:
+            _LOGGER.error("Timeout communicating with Thermotec API: %s", err)
             raise UpdateFailed(f"Error communicating with API: {err}")
         except InvalidResponse as err:
+            _LOGGER.error("Invalid response from Thermotec API: %s", err)
+            raise UpdateFailed(f"Error communicating with API: {err}")
+        except Exception as err:
+            _LOGGER.error("Unexpected error communicating with Thermotec API: %s", err)
             raise UpdateFailed(f"Error communicating with API: {err}")
 
     coordinator = DataUpdateCoordinator(

--- a/climate.py
+++ b/climate.py
@@ -98,7 +98,7 @@ class ThermotecAeroflowClimateEntity(ThermotecAeroflowEntity, ClimateEntity, ABC
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_preset_modes = [PRESET_HOME, PRESET_AWAY, PRESET_BOOST]
     _attr_hvac_mode = HVACMode.HEAT
-    _attr_hvac_modes = [HVAC_MODES]
+    _attr_hvac_modes = [HVACMode.HEAT]
 
     def __init__(self, coordinator: DataUpdateCoordinator, client: Client, identifier: str,
                  entity: HomeAssistantModuleData):


### PR DESCRIPTION
- Fixed hvac_modes attribute: Changed from [HVAC_MODES] to [HVACMode.HEAT] This resolves the 'unhashable type: list' TypeError when Google Assistant tries to serialize climate entities
- Added more detailed error logging in coordinator's async_update_data to help diagnose API communication issues
- Added catch-all exception handler for unexpected errors

Fixes #13